### PR TITLE
issue/16: Fix dispatcher repo name value

### DIFF
--- a/charts/dispatcher-service/values.yaml
+++ b/charts/dispatcher-service/values.yaml
@@ -8,7 +8,7 @@ fullnameOverride: ""
 replicaCount: 1
 
 image:
-  repository: ghcr.io/flam-flam/dispatcher-service
+  repository: ghcr.io/flam-flam/dispatcher
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
<!-- Write a description here -->

<!-- Which issue is this PR resolving -->
Closes #16 

## Changes made
- Fix image repo url for the dispatcher service:
`ghcr.io/flam-flam/dispatcher-service` -> `ghcr.io/flam-flam/dispatcher`

## Notes for the reviewer
- Tested locally with `make tilt-up`

## Checklist
- [x] Correct version increment expected: `#patch`
- [ ] ~Tests updated _(if applicable)_~
- [ ] ~Docs updated _(if applicable)_~
