### PR TITLE
flam-flam/dispatcher-service#23 Added a readme and secret creation instructions

### DIFF
--- a/charts/dispatcher-service/Chart.yaml
+++ b/charts/dispatcher-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dispatcher-service
 description: A Helm chart for flam-flam/dispatcher-service
 type: application
-version: 0.1.0
-appVersion: "0.5.0"
+version: 0.1.1
+appVersion: "0.6.0"
 
 home: https://flam-flam.github.io
 sources:

--- a/charts/dispatcher-service/README.md
+++ b/charts/dispatcher-service/README.md
@@ -1,0 +1,25 @@
+# Dispatcher service Helm chart
+
+Helm chart for [flam-flam/dispatcher-service](https://github.com/flam-flam/dispatcher-service).
+
+See `values.yaml` for config reference.
+
+## Secret
+
+Helm values references a secret file that needs to be created manually:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dispatcher-service-secrets
+type: Opaque
+data:
+  REDDIT_CLIENT_ID: <echo -n "VALUE" | base64>
+  REDDIT_CLIENT_SECRET: <echo -n "VALUE" | base64>
+```
+
+## Config
+
+The contents of the `config` section of the values file is mapped directly into
+the dispatcher's `config.json`.

--- a/charts/dispatcher-service/values.yaml
+++ b/charts/dispatcher-service/values.yaml
@@ -32,8 +32,8 @@ secretName: dispatcher-service-secrets
 #   name: dispatcher-service-secrets
 # type: Opaque
 # data:
-#   REDDIT_CLIENT_ID: <base64 encoded value>
-#   REDDIT_CLIENT_SECRET: <base64 encoded value>
+#   REDDIT_CLIENT_ID: <echo -n "VALUE" | base64>
+#   REDDIT_CLIENT_SECRET: <echo -n "VALUE" | base64>
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
<!-- Write a description here -->
Added a clarification for dispatcher service helm chart usage.

<!-- Which issue is this PR resolving -->
Relates to flam-flam/dispatcher-service#23

## Changes made
- Bumped image & chart versions
- Added readme explaining secret prerequisite

## Notes for the reviewer
- This is done off the back of me using `echo` instead of `echo -n` when converting the kubernetes secrets into base64

## Checklist
- [x] Correct version increment expected (manual)
- [ ] ~~Tests updated _(if applicable)_~~
- [x] Docs updated _(if applicable)_
