### PR TITLE
#20 add Helm dependency repos before running chart-releaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Install Helm
         uses: azure/setup-helm@v3
+      - name: Add Helm dependencies
+        run: |
+          helm repo add flam-flam https://flam-flam.github.io/helm-charts
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 #1.5.0
         env:


### PR DESCRIPTION
Attempt to fix release pipeline following helm/chart-releaser-action#74

Contributes to #20 

## Changes made
- Add flam-flam helm repo before running chart-releaser action
