### PR TITLE
#20 trigger the release when the workflow changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'charts/**'
+      - '.github/workflows/release.yaml'
 
 jobs:
   release:


### PR DESCRIPTION
If the pipeline fails and doesn't release the chart due to the workflow bug (like in this case when we needed to add the chart dependencies before releasing), we need to be able to run it again with a fix and without a dummy changes to the chart.

Contributes to release of #20

## Changes made
- Run the release workflow if the workflow itself is changed