### PR TITLE
#13 add a submission service helm chart

### DIFF
--- a/charts/comment-service/values.yaml
+++ b/charts/comment-service/values.yaml
@@ -61,7 +61,7 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
 

--- a/charts/flam-flam/Chart.yaml
+++ b/charts/flam-flam/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: flam-flam
 description: An umbrella chart for flam-flam services
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.0.0"
 
 home: https://flam-flam.github.io
@@ -19,6 +19,9 @@ dependencies:
     repository: https://flam-flam.github.io/helm-charts
   - name: comment-service
     version: 0.2.0
+    repository: https://flam-flam.github.io/helm-charts
+  - name: submission-service
+    version: 0.1.0
     repository: https://flam-flam.github.io/helm-charts
   - name: mongodb
     version: 0.1.0

--- a/charts/submission-service/Chart.yaml
+++ b/charts/submission-service/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: submission-service
+description: A Helm chart for the submission service in flam-flam
+type: application
+version: 0.1.0
+appVersion: "0.2.0"
+
+home: https://flam-flam.github.io
+sources:
+  - https://github.com/flam-flam/submission-service
+  - https://github.com/flam-flam/helm-charts/tree/main/charts/submission-service

--- a/charts/submission-service/README.md
+++ b/charts/submission-service/README.md
@@ -1,0 +1,18 @@
+# Submission service Helm chart
+
+Helm chart for [flam-flam/submission-service](https://github.com/flam-flam/submission-service).
+
+See `values.yaml` for config reference.
+
+## Mongo DB connection
+
+### Endpoint
+
+The endpoint is set in `mongo.server` value of `values.yaml`.
+
+### Secret
+
+MongoDB secrets are read from `mongo.secret` value of `values.yaml`.
+It is read from the secret with the `name` and keys set in `username` and `password`, where the respective values are set.
+
+>NOTE: this is created within the [mongodb helm chart](../charts/mongodb)

--- a/charts/submission-service/templates/_helpers.tpl
+++ b/charts/submission-service/templates/_helpers.tpl
@@ -1,0 +1,78 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "submission-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "submission-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "submission-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "submission-service.labels" -}}
+helm.sh/chart: {{ include "submission-service.chart" . }}
+{{ include "submission-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "submission-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "submission-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "submission-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "submission-service.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+MongoDB server endpoint
+*/}}
+{{- define "submission-service.mongo-server" -}}
+{{- $defaultEndpoint := printf "%s-mongodb" .Release.Name -}}
+{{- default $defaultEndpoint .Values.mongo.server }}
+{{- end }}
+
+{{/*
+MongoDB secret
+*/}}
+{{- define "submission-service.mongo-secret" -}}
+{{- $defaultName := printf "%s-mongodb-root" .Release.Name -}}
+{{- default $defaultName .Values.mongo.secret.name }}
+{{- end }}

--- a/charts/submission-service/templates/deployment.yaml
+++ b/charts/submission-service/templates/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "submission-service.fullname" . }}
+  labels:
+    {{- include "submission-service.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "submission-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "submission-service.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "submission-service.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: MONGO_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "submission-service.mongo-secret" . }}
+                  key: {{ .Values.mongo.secret.usernameKey }}
+            - name: MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "submission-service.mongo-secret" . }}
+                  key: {{ .Values.mongo.secret.passwordKey }}
+            - name: MONGO_SERVER
+              value: {{ include "submission-service.mongo-server" . }}
+            - name: MONGO_PORT
+              value: "{{ .Values.mongo.port }}"
+            - name: MONGO_CONNECTION_STRING
+              value: mongodb://$(MONGO_USERNAME):$(MONGO_PASSWORD)@$(MONGO_SERVER):$(MONGO_PORT)
+            - name: MONGO_DATABASE_NAME
+              value: flam
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/submission-service/templates/hpa.yaml
+++ b/charts/submission-service/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "submission-service.fullname" . }}
+  labels:
+    {{- include "submission-service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "submission-service.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/submission-service/templates/service.yaml
+++ b/charts/submission-service/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "submission-service.fullname" . }}
+  labels:
+    {{- include "submission-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "submission-service.selectorLabels" . | nindent 4 }}

--- a/charts/submission-service/templates/serviceaccount.yaml
+++ b/charts/submission-service/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "submission-service.serviceAccountName" . }}
+  labels:
+    {{- include "submission-service.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/submission-service/templates/tests/test-connection.yaml
+++ b/charts/submission-service/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "submission-service.fullname" . }}-test-connection"
+  labels:
+    {{- include "submission-service.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "submission-service.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/submission-service/values.yaml
+++ b/charts/submission-service/values.yaml
@@ -1,0 +1,70 @@
+# Default values for submission-service.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+---
+replicaCount: 1
+
+image:
+  repository: ghcr.io/flam-flam/submission
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+mongo:
+  server: ""
+  port: 27017
+  secret:
+    name: ""
+    usernameKey: username
+    passwordKey: password
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8000
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Add a Helm chart for the submission service. It looks essentially the same as the comment service

<!-- Which issue is this PR resolving -->
Contributes to #13 
## Changes made
- new helm chart
- added new helm chart to the umbrella chart
- umbrella chart version bump
- a fix to autoscaling in values.yaml

## Notes for the reviewer
- It's not yet possible to test the umbrella chart because the submission service chart was not published yet

## Checklist
- [x] Tests updated _(if applicable)_
- [x] Docs updated _(if applicable)_
